### PR TITLE
Add basic test to word API

### DIFF
--- a/spec/services/words_spec.rb
+++ b/spec/services/words_spec.rb
@@ -8,7 +8,10 @@ RSpec.describe 'Words Api' do
     
     it "creates a new word from api" do
       expect(@word).to be_a(String)
+      expect(@word).to_be capitalize 
+      within('@word') do
+        expect( all('.find_word').count ).to eq(1)
+      end
     end
-
   end
 end


### PR DESCRIPTION
I am having issues with VCR and the pulling multiple words, as for the testing for the single word it only returns a string, no hash, no array just a string that is why testing is so light. I will continue to trouble shoot the multi word response a little later today
![Screen Shot 2023-05-25 at 10 25 36 AM](https://github.com/Correct-or-Crass/Trivia_API/assets/108754743/71448f6e-d2fa-46f9-b1ef-8e0ccf98fd1c)
![Screen Shot 2023-05-25 at 10 25 47 AM](https://github.com/Correct-or-Crass/Trivia_API/assets/108754743/64d0d18a-c764-45f7-b0c4-508dbf6c4075)
