### PR TITLE
SA Error Handling#route_not_found

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,4 @@
+require "./lib/modules/errors/error_handler.rb"
 class ApplicationController < ActionController::API
+  include ErrorHandler
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,9 +1,7 @@
 Rails.application.routes.draw do
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
-
-  # Defines the root path route ("/")
-  # root "articles#index"
-  # resources :trivia, only: :index
+  
+  match '*unmatched', to: 'application#route_not_found', via: :all 
   
   namespace :api do
     namespace :v1 do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,12 +1,12 @@
 Rails.application.routes.draw do
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
   
-  match '*unmatched', to: 'application#route_not_found', via: :all 
-  
   namespace :api do
     namespace :v1 do
       resources :endgame_apis, only: :index
       resources :game_play_apis, only: :index
     end
   end
+  
+  match '*unmatched', to: 'application#route_not_found', via: :all 
 end

--- a/lib/modules/errors/error_handler.rb
+++ b/lib/modules/errors/error_handler.rb
@@ -1,0 +1,10 @@
+require_relative "./error_serializer.rb"
+
+module ErrorHandler 
+  def route_not_found
+    detail_message = params[:action].split("_").join(" ")
+    status_code = 400
+    source_info = request.original_fullpath
+    render json: ErrorSerializer.bad_request(detail_message, status_code, source_info), status: :bad_request
+  end
+end

--- a/lib/modules/errors/error_serializer.rb
+++ b/lib/modules/errors/error_serializer.rb
@@ -9,7 +9,6 @@ class ErrorSerializer
           status: status_code.to_s, 
           source: {
                    "pointer": source_info,
-                   "parameter": source_info.split("/").last
                     }
           } 
         ]

--- a/lib/modules/errors/error_serializer.rb
+++ b/lib/modules/errors/error_serializer.rb
@@ -1,0 +1,18 @@
+class ErrorSerializer
+  def self.bad_request(detail_message, status_code, source_info)
+    {
+        errors:
+        [ 
+          {
+          title: "Bad Request",
+          detail: detail_message,
+          status: status_code.to_s, 
+          source: {
+                   "pointer": source_info,
+                   "parameter": source_info.split("/").last
+                    }
+          } 
+        ]
+    }
+  end
+end

--- a/lib/modules/errors/error_serializer.rb
+++ b/lib/modules/errors/error_serializer.rb
@@ -8,8 +8,8 @@ class ErrorSerializer
           detail: detail_message,
           status: status_code.to_s, 
           source: {
-                   "pointer": source_info,
-                    }
+                   pointer: source_info,
+                  }
           } 
         ]
     }

--- a/spec/requests/error_request_spec.rb
+++ b/spec/requests/error_request_spec.rb
@@ -23,23 +23,20 @@ RSpec.describe "Error Requests" do
         expect(parsed_response[:errors][0][:status]).to be_a(String)
 
         expect(parsed_response[:errors][0][:source]).to be_a(Hash)
-        expect(parsed_response[:errors][0][:source].keys).to eq([:pointer, :parameter])
+        expect(parsed_response[:errors][0][:source].keys).to eq([:pointer])
 
         expect(parsed_response[:errors][0][:source][:pointer]).to be_a(String)
-        expect(parsed_response[:errors][0][:source][:parameter]).to be_a(String)
       end
 
       it "response includes detailed informaiton about the error" do 
-        get "/api/v1/usertypedinwhatevertheywanted-notanendpoint!"
+        get "/api/v11/gameplay"
         
         parsed_response = Serviceable.parse_json(response)
-
+        # require 'pry';binding.pry
         expect(parsed_response[:errors][0][:title]).to eq("Bad Request")
         expect(parsed_response[:errors][0][:detail]).to eq("route not found")
         expect(parsed_response[:errors][0][:status]).to eq("400")
-
         expect(parsed_response[:errors][0][:source][:pointer]).to eq(request.original_fullpath)
-        expect(parsed_response[:errors][0][:source][:parameter]).to eq("usertypedinwhatevertheywanted-notanendpoint!") #this matches the end of the URI
       end
     end
   end

--- a/spec/requests/error_request_spec.rb
+++ b/spec/requests/error_request_spec.rb
@@ -1,0 +1,46 @@
+require "rails_helper"
+require "./lib/modules/serviceable"
+
+RSpec.describe "Error Requests" do
+  describe "#route_not_found captures any invalid url" do
+    context "expect reponse to have error objects with three level" do
+      it "inspects the different keys & values datatypes" do
+        get "/api/v1/game_play_apissssss"
+        expect(response.status).to eq(400)
+        
+        parsed_response = Serviceable.parse_json(response)
+    
+        expect(parsed_response).to be_a(Hash)
+        expect(parsed_response.keys).to eq([:errors])
+
+        expect(parsed_response[:errors]).to be_a(Array)
+        expect(parsed_response[:errors].count).to eq(1)
+
+        expect(parsed_response[:errors][0].keys).to eq([:title, :detail, :status, :source])
+        
+        expect(parsed_response[:errors][0][:title]).to be_a(String)
+        expect(parsed_response[:errors][0][:detail]).to be_a(String)
+        expect(parsed_response[:errors][0][:status]).to be_a(String)
+
+        expect(parsed_response[:errors][0][:source]).to be_a(Hash)
+        expect(parsed_response[:errors][0][:source].keys).to eq([:pointer, :parameter])
+
+        expect(parsed_response[:errors][0][:source][:pointer]).to be_a(String)
+        expect(parsed_response[:errors][0][:source][:parameter]).to be_a(String)
+      end
+
+      it "response includes detailed informaiton about the error" do 
+        get "/api/v1/usertypedinwhatevertheywanted-notanendpoint!"
+        
+        parsed_response = Serviceable.parse_json(response)
+
+        expect(parsed_response[:errors][0][:title]).to eq("Bad Request")
+        expect(parsed_response[:errors][0][:detail]).to eq("route not found")
+        expect(parsed_response[:errors][0][:status]).to eq("400")
+
+        expect(parsed_response[:errors][0][:source][:pointer]).to eq(request.original_fullpath)
+        expect(parsed_response[:errors][0][:source][:parameter]).to eq("usertypedinwhatevertheywanted-notanendpoint!") #this matches the end of the URI
+      end
+    end
+  end
+end

--- a/spec/requests/error_request_spec.rb
+++ b/spec/requests/error_request_spec.rb
@@ -3,7 +3,7 @@ require "./lib/modules/serviceable"
 
 RSpec.describe "Error Requests" do
   describe "#route_not_found captures any invalid url" do
-    context "expect reponse to have error objects with three level" do
+    context "expect reponse to have error objects with three levels" do
       it "inspects the different keys & values datatypes" do
         get "/api/v1/game_play_apissssss"
         expect(response.status).to eq(400)

--- a/spec/requests/error_request_spec.rb
+++ b/spec/requests/error_request_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe "Error Requests" do
         get "/api/v11/gameplay"
         
         parsed_response = Serviceable.parse_json(response)
-        # require 'pry';binding.pry
+
         expect(parsed_response[:errors][0][:title]).to eq("Bad Request")
         expect(parsed_response[:errors][0][:detail]).to eq("route not found")
         expect(parsed_response[:errors][0][:status]).to eq("400")


### PR DESCRIPTION
`ErrorHandler` is a module that will host methods to handle other error types

`#route_not_found` captures and handles any incoming invalid url 

#route_not_found `Response`:
- an error hash that adheres to `JSON:API` standards
- tested for expected error object levels and data types
- tested for expected human readable messages

all `GREEN` at push