### PR TITLE
Bundler fix

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -138,6 +138,7 @@ GEM
     matrix (0.4.2)
     method_source (1.0.0)
     mini_mime (1.1.2)
+    mini_portile2 (2.8.4)
     minitest (5.18.0)
     msgpack (1.7.0)
     multi_xml (0.6.0)
@@ -152,6 +153,9 @@ GEM
     net-smtp (0.3.3)
       net-protocol
     nio4r (2.5.9)
+    nokogiri (1.15.1)
+      mini_portile2 (~> 2.8.2)
+      racc (~> 1.4)
     nokogiri (1.15.1-x86_64-darwin)
       racc (~> 1.4)
     nokogiri (1.15.1-x86_64-linux)
@@ -265,6 +269,7 @@ GEM
     zeitwerk (2.6.8)
 
 PLATFORMS
+  ruby
   x86_64-darwin-21
   x86_64-darwin-22
   x86_64-linux


### PR DESCRIPTION
-[x] Adds platform-ruby to Gemfile.lock to fix Heroku bundler dependency