### PR TITLE
feat: Downgrades bundler to match heroku buildpack

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -302,4 +302,4 @@ RUBY VERSION
    ruby 3.2.2p53
 
 BUNDLED WITH
-   2.4.17
+   2.3.25


### PR DESCRIPTION
-[x] Downgrade bundler in Gemfile.lock to 2.3.25 to match Heroku buildpack (bundler version static in Heroku)